### PR TITLE
Don't allow scrolling left or right on mobile images page

### DIFF
--- a/js/stills/constants.js
+++ b/js/stills/constants.js
@@ -5,7 +5,7 @@ const NEXT_IMAGE_MAX_DELTA = 200;
 
 // How many pixels there will be between the sides of the image and the edge
 // of the window at a minimum when a new image is inserted
-const X_AXIS_MARGIN = -100;
+const X_AXIS_MARGIN = 0;
 
 // If an image's size is selected as too large, this number is how much
 // to divide that size by to try again


### PR DESCRIPTION
Images used to go off the right and left of the screen on the still page.

This seemed like a cool idea, but it made scrolling around really weird on mobile. So I removed that.